### PR TITLE
feat: add unified docker build action

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,303 @@
+# GitHub Action Build Docker
+
+Build and push Docker images with native or cross-platform support.
+
+## Features
+
+- Native builds by default (no QEMU overhead)
+- Optional QEMU for cross-platform builds
+- Docker layer caching with registry backend
+- Flexible build arguments, secrets, and contexts
+- Single platform per invocation (for multi-arch orchestration)
+- Outputs image digest for manifest creation
+
+## Prerequisites
+
+Create a `.docker-config.json` file in your repository root:
+
+```json
+{
+  "imageName": "your-org/your-image",
+  "dockerfile": "./Dockerfile"
+}
+```
+
+- `imageName` (required): Docker image name in format `org/name`
+- `dockerfile` (optional): Path to Dockerfile, defaults to `./Dockerfile`
+
+**Example:**
+
+```json
+{
+  "imageName": "turo/my-microservice",
+  "dockerfile": "./Dockerfile"
+}
+```
+
+## Usage
+
+### Basic Usage
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+
+  - name: Build and push Docker image
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: 1.0.0
+```
+
+### With Semantic Release
+
+```yaml
+steps:
+  - name: Release
+    uses: open-turo/actions-node/release@v5
+    id: release
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  - name: Build and push
+    if: steps.release.outputs.new-release-published == 'true'
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: ${{ steps.release.outputs.new-release-version }}
+      metadata-tags: |
+        type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
+        type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.new-release-version }}
+```
+
+### Build for Specific Platform
+
+```yaml
+steps:
+  - name: Build ARM64 image
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: 1.0.0
+      image-platform: linux/arm64
+      install-qemu: true # Only needed if building on AMD64 runner
+```
+
+### Local Build for Testing
+
+```yaml
+steps:
+  - name: Build image locally
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: test
+      push: false
+      load: true
+
+  - name: Run integration tests
+    run: |
+      docker run my-org/my-image:test
+```
+
+### Security Scanning
+
+```yaml
+steps:
+  - name: Build image
+    uses: open-turo/actions-docker/build@v1
+    id: build
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: ${{ github.sha }}
+      push: false
+      load: true
+
+  - name: Scan image
+    uses: aquasecurity/trivy-action@master
+    with:
+      image-ref: ${{ steps.build.outputs.image }}
+```
+
+### With Build Arguments
+
+```yaml
+steps:
+  - name: Build with custom args
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: 1.0.0
+      build-args: |
+        NODE_ENV=production
+        API_URL=https://api.example.com
+```
+
+### With Build Secrets
+
+For secrets like NPM tokens, Artifactory credentials, etc:
+
+```yaml
+steps:
+  - name: Build with secrets
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: 1.0.0
+      secrets: |
+        NPM_TOKEN=${{ secrets.NPM_TOKEN }}
+        ARTIFACTORY_USERNAME=${{ secrets.ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_AUTH_TOKEN=${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+```
+
+Then in your Dockerfile:
+
+```dockerfile
+RUN --mount=type=secret,id=NPM_TOKEN \
+    echo "//registry.npmjs.org/:_authToken=$(cat /run/secrets/NPM_TOKEN)" > .npmrc && \
+    npm install
+```
+
+### Disable Caching
+
+```yaml
+steps:
+  - name: Build without cache
+    uses: open-turo/actions-docker/build@v1
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      image-version: 1.0.0
+      cache: false
+```
+
+## Multi-Architecture Builds
+
+For multi-architecture images, invoke this action separately for each platform, then create a manifest:
+
+```yaml
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build AMD64
+        uses: open-turo/actions-docker/build@v1
+        id: build-amd64
+        with:
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          image-version: ${{ needs.release.outputs.version }}
+          image-platform: linux/amd64
+          push: true
+
+    outputs:
+      digest: ${{ steps.build-amd64.outputs.digest }}
+
+  build-arm64:
+    runs-on: ubuntu-latest # or use ARM64 runners for native builds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ARM64
+        uses: open-turo/actions-docker/build@v1
+        id: build-arm64
+        with:
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          image-version: ${{ needs.release.outputs.version }}
+          image-platform: linux/arm64
+          push: true
+          install-qemu: true # Only if cross-compiling on AMD64
+
+    outputs:
+      digest: ${{ steps.build-arm64.outputs.digest }}
+
+  create-manifest:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create multi-arch manifest
+        env:
+          IMAGE_NAME: your-org/your-image
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION} \
+            ${IMAGE_NAME}@${{ needs.build-amd64.outputs.digest }} \
+            ${IMAGE_NAME}@${{ needs.build-arm64.outputs.digest }}
+```
+
+## Inputs
+
+| Name                 | Description                                       | Required | Default               |
+| -------------------- | ------------------------------------------------- | -------- | --------------------- |
+| `docker-config-file` | Path to docker config file                        | No       | `.docker-config.json` |
+| `dockerhub-user`     | DockerHub username                                | Yes      |                       |
+| `dockerhub-password` | DockerHub password                                | Yes      |                       |
+| `image-version`      | Docker image version/tag                          | Yes      |                       |
+| `image-platform`     | Target platform (e.g., linux/amd64, linux/arm64)  | No       | `linux/amd64`         |
+| `push`               | Push image to registry                            | No       | `true`                |
+| `load`               | Load image to local docker (single-platform only) | No       | `false`               |
+| `cache`              | Enable Docker layer caching                       | No       | `true`                |
+| `cache-tag`          | Cache tag name                                    | No       | `buildcache`          |
+| `metadata-tags`      | Docker metadata-action tags input                 | No       |                       |
+| `metadata-flavor`    | Docker metadata-action flavor input               | No       | `latest=false`        |
+| `build-args`         | Build arguments (KEY=VALUE, one per line)         | No       |                       |
+| `secrets`            | Build secrets (KEY=VALUE, one per line)           | No       |                       |
+| `build-contexts`     | Build contexts (KEY=VALUE, one per line)          | No       |                       |
+| `install-qemu`       | Install QEMU for cross-platform builds            | No       | `false`               |
+| `qemu-platforms`     | QEMU platforms (defaults to image-platform)       | No       |                       |
+
+## Outputs
+
+| Name         | Description                     |
+| ------------ | ------------------------------- |
+| `image-name` | Docker image name               |
+| `image-tag`  | Docker image tag                |
+| `image`      | Full image reference (name:tag) |
+| `digest`     | Image digest                    |
+
+## Standard Build Arguments
+
+These build arguments are automatically provided to your Dockerfile:
+
+- `GIT_COMMIT` - Current git commit SHA
+- `BUILDTIME` - Build timestamp
+- `VERSION` - Image version (from `image-version` input)
+- `REVISION` - Image revision (from `image-version` input)
+- `BRANCH` - Git branch name
+
+Example Dockerfile usage:
+
+```dockerfile
+ARG VERSION
+ARG GIT_COMMIT
+ARG BUILDTIME
+
+LABEL org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILDTIME}"
+```
+
+## Notes
+
+- **QEMU Performance**: Cross-platform builds using QEMU are significantly slower than native builds. Use native runners (ARM64 runners for ARM64 builds) when possible.
+- **Load Limitation**: You cannot use `load: true` with multi-platform builds. Load is only supported for single-platform builds.
+- **Caching**: Layer caching uses the registry backend with the specified `cache-tag`. The cache is stored alongside your image in the registry.

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -1,0 +1,160 @@
+name: Build & push docker images
+description: Build and push docker images with native or cross-platform support
+inputs:
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.
+    default: .docker-config.json
+  dockerhub-user:
+    required: true
+    description: DockerHub username
+  dockerhub-password:
+    required: true
+    description: DockerHub password
+  image-version:
+    required: true
+    description: Docker image version/tag
+  image-platform:
+    description: Target platform to build image for (e.g., linux/amd64, linux/arm64)
+    required: false
+    default: linux/amd64
+  push:
+    required: false
+    default: "true"
+    description: Push image to registry
+  load:
+    required: false
+    default: "false"
+    description: Load image to local docker (single-platform only)
+  cache:
+    required: false
+    default: "true"
+    description: Enable Docker layer caching
+  cache-tag:
+    required: false
+    default: buildcache
+    description: Cache tag name
+  metadata-tags:
+    description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input
+    required: false
+  metadata-flavor:
+    description: Docker metadata-action flavor input. See https://github.com/docker/metadata-action#flavor-input
+    required: false
+    default: latest=false
+  build-args:
+    required: false
+    description: List of build arguments as key-value pairs (e.g., KEY=VALUE, one per line)
+    default: ""
+  secrets:
+    required: false
+    description: List of build secrets as key-value pairs (e.g., KEY=VALUE, one per line)
+    default: ""
+  build-contexts:
+    required: false
+    description: List of build contexts as key-value pairs (e.g., CONTEXT_KEY=VALUE, one per line)
+    default: ""
+  install-qemu:
+    required: false
+    default: "false"
+    description: Install QEMU for cross-platform builds
+  qemu-platforms:
+    required: false
+    description: QEMU platforms to install (defaults to image-platform if not set)
+outputs:
+  image-name:
+    description: Docker image name
+    value: ${{ steps.config.outputs.image-name }}
+  image-tag:
+    description: Docker image tag
+    value: ${{ inputs.image-version }}
+  image:
+    description: Full image reference (name:tag)
+    value: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+  digest:
+    description: Image digest
+    value: ${{ steps.build.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dump GitHub context
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
+    - id: config
+      name: Read docker config
+      shell: bash
+      env:
+        DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+        IMAGE_VERSION: ${{ inputs.image-version }}
+        IMAGE_PLATFORM: ${{ inputs.image-platform }}
+        METADATA_TAGS: ${{ inputs.metadata-tags }}
+      run: |
+        # Validate docker config file exists
+        if [ ! -f "$DOCKER_CONFIG_FILE" ]; then
+          echo "::error::Docker config file not found: $DOCKER_CONFIG_FILE" && exit 1
+        fi
+
+        # Parse config file
+        image_name=$(jq -r .imageName "$DOCKER_CONFIG_FILE")
+        if [ -z "$image_name" ] || [ "$image_name" = "null" ]; then
+          echo "::error::imageName not found in $DOCKER_CONFIG_FILE" && exit 1
+        fi
+        echo "image-name: ${image_name}"
+        echo "image-name=${image_name}" >> $GITHUB_OUTPUT
+
+        dockerfile=$(jq -r '.dockerfile // "./Dockerfile"' "$DOCKER_CONFIG_FILE")
+        echo "Dockerfile: ${dockerfile}"
+        echo "dockerfile=${dockerfile}" >> $GITHUB_OUTPUT
+
+        echo "image-version: $IMAGE_VERSION"
+        echo "image-platform: $IMAGE_PLATFORM"
+        echo "metadata-tags: $METADATA_TAGS"
+
+    - name: Set up QEMU
+      if: inputs.install-qemu == 'true'
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ inputs.qemu-platforms || inputs.image-platform }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-user }}
+        password: ${{ inputs.dockerhub-password }}
+
+    - name: Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ steps.config.outputs.image-name }}
+        flavor: ${{ inputs.metadata-flavor }}
+        tags: ${{ inputs.metadata-tags }}
+
+    - name: Build and push
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: ${{ inputs.image-platform }}
+        file: ${{ steps.config.outputs.dockerfile }}
+        build-contexts: ${{ inputs.build-contexts }}
+        build-args: |
+          GIT_COMMIT=${{ github.sha }}
+          BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          VERSION=${{ inputs.image-version }}
+          REVISION=${{ inputs.image-version }}
+          BRANCH=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+          ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        tags: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: ${{ inputs.cache == 'true' && format('type=registry,ref={0}:{1}', steps.config.outputs.image-name, inputs.cache-tag) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && format('type=registry,ref={0}:{1},mode=max,compression=zstd', steps.config.outputs.image-name, inputs.cache-tag) || '' }}


### PR DESCRIPTION
## Summary

Create a modern, flexible docker build action that consolidates functionality from:
- `open-turo/actions-node/build-docker`
- `open-turo/actions-jvm/build-docker`
- `open-turo/actions-security/docker-build`

## Key Features

- **Native builds by default** - QEMU is opt-in via `install-qemu: false` for better performance
- **Single platform per invocation** - Designed for multi-arch orchestration (invoke separately for each platform)
- **Generic secrets/build-args** - No technology-specific inputs (NPM, Artifactory, etc.)
- **Registry-based layer caching** - With zstd compression for optimal performance
- **Flexible outputs** - Returns image name, tag, full reference, and digest for manifest creation
- **Push/load options** - Support for different workflows (CI/CD push, local testing, security scanning)

## Benefits

- Clean, modern API without backward compatibility burden
- Supports all existing use cases from the three source actions
- Better performance with native builds (no QEMU overhead by default)
- Enables multi-arch build patterns with digest outputs

## Design Decisions

- **No .docker-config.json in repo** - This file is created by consuming repos, not the action repo itself
- **Major version tags** - Using `@v3`, `@v5`, `@v6` for auto-updates per Docker best practices
- **Standard build args** - Auto-includes GIT_COMMIT, VERSION, BUILDTIME, REVISION, BRANCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)