### PR TITLE
feat: add multi-arch docker manifest action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,6 @@ jobs:
       - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test shell scripts
+        run: ./manifest/test-create-manifest.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,106 @@
 # actions-docker
 
 GitHub Actions for building, pushing and tagging docker images.
+
+## Actions
+
+### [build](./build)
+
+Build and push Docker images with native or cross-platform support.
+
+### [manifest](./manifest)
+
+Combine platform-specific Docker images into a single multi-arch manifest.
+
+## Multi-Architecture Builds
+
+Build Docker images for multiple architectures (AMD64, ARM64) using native runners for optimal performance.
+
+### Workflow Pattern
+
+```mermaid
+flowchart TD
+    A[AMD64 Runner<br/>actions-docker/build] --> C[AMD64 Digest]
+    B[ARM64 Runner<br/>actions-docker/build] --> D[ARM64 Digest]
+    C --> E[actions-docker/manifest]
+    D --> E
+    E --> F[Multi-arch Image<br/>linux/amd64 + linux/arm64]
+```
+
+### Why Multi-Arch?
+
+1. **Native Builds Performance**: Build each platform on native runners (ARM64 on ARM, AMD64 on AMD) for maximum performance
+2. **Explicit Control**: Explicit manifest creation gives you full control over the multi-arch image
+3. **Multiple Tags**: Apply multiple tags (e.g., version + latest) in one step
+4. **Clean Workflow**: Separate build and manifest creation concerns
+
+### Complete Example
+
+```yaml
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build AMD64
+        uses: open-turo/actions-docker/build@v1
+        id: build
+        with:
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          image-version: 1.0.0
+          image-platform: linux/amd64
+          push: true
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+  build-arm64:
+    runs-on: ubuntu-arm-runner # Native ARM64 runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ARM64
+        uses: open-turo/actions-docker/build@v1
+        id: build
+        with:
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          image-version: 1.0.0
+          image-platform: linux/arm64
+          push: true
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+  create-manifest:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create multi-arch manifest
+        uses: open-turo/actions-docker/manifest@v1
+        with:
+          image-name: myorg/myimage
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: 1.0.0,latest
+          sources: |
+            myorg/myimage@${{ needs.build-amd64.outputs.digest }}
+            myorg/myimage@${{ needs.build-arm64.outputs.digest }}
+```
+
+### How It Works
+
+1. **Build Phase**: Each platform (AMD64, ARM64) is built separately on native runners
+2. **Push Phase**: Each platform-specific image is pushed to the registry with the same tags
+3. **Manifest Phase**: The manifest action combines the platform images using their digests into a single multi-arch manifest
+4. **Pull Phase**: When users pull the image, Docker automatically selects the appropriate platform-specific image
+
+### Notes
+
+- **Digests vs Tags**: Using digests (e.g., `@sha256:...`) is more reliable than tags as it ensures you're referencing the exact image that was built
+- **Multiple Tags**: You can create multiple tags for the same manifest (e.g., `1.0.0` and `latest`) by providing a comma-separated list
+- **Native Performance**: Cross-platform builds using QEMU are significantly slower than native builds. Use native runners when possible.

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -1,0 +1,73 @@
+# GitHub Action Create Multi-Arch Docker Manifest
+
+Combine platform-specific Docker images into a single multi-arch manifest.
+
+## Features
+
+- Combine ARM64 and AMD64 images built on native runners
+- Support multiple tags for the manifest
+- Use Docker Buildx imagetools for manifest creation
+- Simple, explicit inputs (no config file needed)
+- Outputs manifest reference for further use
+
+## Usage
+
+### Basic Usage
+
+```yaml
+- name: Create multi-arch manifest
+  uses: open-turo/actions-docker/manifest@v1
+  with:
+    image-name: myorg/myimage
+    dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+    dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+    tags: 1.0.0,latest
+    sources: |
+      myorg/myimage@${{ needs.build-amd64.outputs.digest }}
+      myorg/myimage@${{ needs.build-arm64.outputs.digest }}
+```
+
+### Using Tag-Based References
+
+Instead of digests, you can also use tag-based references:
+
+```yaml
+- name: Create multi-arch manifest
+  uses: open-turo/actions-docker/manifest@v1
+  with:
+    image-name: myorg/myimage
+    dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+    dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+    tags: 1.0.0,latest
+    sources: |
+      myorg/myimage:1.0.0-amd64
+      myorg/myimage:1.0.0-arm64
+```
+
+## Inputs
+
+| Name                 | Description                                                                                          | Required |
+| -------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
+| `image-name`         | Docker image name (e.g., org/image-name)                                                             | Yes      |
+| `dockerhub-user`     | DockerHub username                                                                                   | Yes      |
+| `dockerhub-password` | DockerHub password                                                                                   | Yes      |
+| `tags`               | Comma-separated list of tags to apply to the manifest (e.g., 1.0.0,latest)                           | Yes      |
+| `sources`            | List of source images to combine (one per line). Can be digests or tags (e.g., org/image@sha256:...) | Yes      |
+
+## Outputs
+
+| Name       | Description                    |
+| ---------- | ------------------------------ |
+| `manifest` | The created manifest reference |
+
+## How It Works
+
+This action uses `docker buildx imagetools create` to combine multiple platform-specific images into a single multi-arch manifest. When users pull the image, Docker automatically selects the appropriate platform-specific image based on their architecture.
+
+## Notes
+
+- **Digests vs Tags**: Using digests (e.g., `@sha256:...`) is more reliable than tags as it ensures you're referencing the exact image that was built
+- **Multiple Tags**: You can create multiple tags for the same manifest (e.g., `1.0.0` and `latest`) by providing a comma-separated list
+- **Authentication**: The action needs DockerHub credentials to push the manifest to the registry
+
+For a complete multi-architecture build example, see the [main README](../README.md#multi-architecture-builds).

--- a/manifest/action.yaml
+++ b/manifest/action.yaml
@@ -1,0 +1,50 @@
+name: Create multi-arch Docker manifest
+description: Combine platform-specific Docker images into a single multi-arch manifest
+inputs:
+  image-name:
+    required: true
+    description: Docker image name (e.g., org/image-name)
+  dockerhub-user:
+    required: true
+    description: DockerHub username
+  dockerhub-password:
+    required: true
+    description: DockerHub password
+  tags:
+    required: true
+    description: Comma-separated list of tags to apply to the manifest (e.g., 1.0.0,latest)
+  sources:
+    required: true
+    description: |
+      List of source images to combine (one per line).
+      Can be full image references with digests (e.g., org/image@sha256:abc123)
+      or image references with tags (e.g., org/image:1.0.0-amd64)
+outputs:
+  manifest:
+    description: The created manifest reference
+    value: ${{ steps.create.outputs.manifest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-user }}
+        password: ${{ inputs.dockerhub-password }}
+
+    - name: Create manifest
+      id: create
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        TAGS: ${{ inputs.tags }}
+        SOURCES: ${{ inputs.sources }}
+      run: |
+        ${{ github.action_path }}/create-manifest.sh \
+          "$IMAGE_NAME" \
+          "$TAGS" \
+          "$SOURCES"

--- a/manifest/create-manifest.sh
+++ b/manifest/create-manifest.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Script to create Docker multi-arch manifests
+# Usage: create-manifest.sh <image-name> <tags> <sources>
+#   image-name: Docker image name (e.g., org/image-name)
+#   tags: Comma-separated list of tags (e.g., 1.0.0,latest)
+#   sources: Newline-separated list of source images (e.g., org/image@sha256:...)
+
+set -euo pipefail
+
+# Check for required arguments
+if [ $# -lt 3 ]; then
+  echo "::error::Usage: create-manifest.sh <image-name> <tags> <sources>"
+  exit 1
+fi
+
+IMAGE_NAME="$1"
+TAGS="$2"
+SOURCES="$3"
+
+# Parse comma-separated tags into array
+IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+
+# Parse newline-separated sources into array
+mapfile -t SOURCE_ARRAY <<< "$SOURCES"
+
+# Remove empty lines from sources
+SOURCE_ARRAY_FILTERED=()
+for source in "${SOURCE_ARRAY[@]}"; do
+  # Trim whitespace
+  source=$(echo "$source" | xargs)
+  # Skip empty lines
+  [ -z "$source" ] && continue
+  SOURCE_ARRAY_FILTERED+=("$source")
+done
+
+# Validate we have sources
+if [ ${#SOURCE_ARRAY_FILTERED[@]} -eq 0 ]; then
+  echo "::error::No source images provided"
+  exit 1
+fi
+
+echo "Creating manifest for ${IMAGE_NAME}"
+echo "Tags: ${TAG_ARRAY[*]}"
+echo "Sources: ${SOURCE_ARRAY_FILTERED[*]}"
+
+# Create manifest for each tag
+for tag in "${TAG_ARRAY[@]}"; do
+  # Trim whitespace
+  tag=$(echo "$tag" | xargs)
+
+  manifest_ref="${IMAGE_NAME}:${tag}"
+  echo "Creating manifest: ${manifest_ref}"
+
+  # Execute imagetools create command with all source images
+  echo "Executing: docker buildx imagetools create -t ${manifest_ref} ${SOURCE_ARRAY_FILTERED[*]}"
+  docker buildx imagetools create -t "${manifest_ref}" "${SOURCE_ARRAY_FILTERED[@]}"
+
+  # Inspect the created manifest
+  echo "Inspecting manifest: ${manifest_ref}"
+  docker buildx imagetools inspect "${manifest_ref}"
+done
+
+# Output the first tag as the primary manifest reference
+echo "manifest=${IMAGE_NAME}:${TAG_ARRAY[0]}" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/manifest/test-create-manifest.sh
+++ b/manifest/test-create-manifest.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+# Test script for create-manifest.sh
+# Mocks docker commands and verifies correct behavior
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Create a temporary directory for mock docker
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Create mock docker script
+cat > "$MOCK_DIR/docker" << 'DOCKER_MOCK_EOF'
+#!/usr/bin/env bash
+echo "[MOCK] docker $*"
+
+# Simulate successful execution
+if [[ "$1" == "buildx" && "$2" == "imagetools" ]]; then
+  if [[ "$3" == "create" ]]; then
+    # Mock imagetools create
+    exit 0
+  elif [[ "$3" == "inspect" ]]; then
+    # Mock imagetools inspect
+    echo "Name:      $4"
+    echo "MediaType: application/vnd.docker.distribution.manifest.list.v2+json"
+    echo "Digest:    sha256:mock1234567890"
+    echo ""
+    echo "Manifests:"
+    echo "  Name:      $4"
+    echo "  MediaType: application/vnd.docker.distribution.manifest.v2+json"
+    echo "  Platform:  linux/amd64"
+    echo ""
+    echo "  Name:      $4"
+    echo "  MediaType: application/vnd.docker.distribution.manifest.v2+json"
+    echo "  Platform:  linux/arm64"
+    exit 0
+  fi
+fi
+exit 1
+DOCKER_MOCK_EOF
+
+chmod +x "$MOCK_DIR/docker"
+
+# Add mock docker to PATH
+export PATH="$MOCK_DIR:$PATH"
+
+# Test helper functions
+pass_test() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+fail_test() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  echo -e "${RED}✗${NC} $1"
+  echo "  Error: $2"
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  local test_name="$1"
+  echo ""
+  echo "Running: $test_name"
+}
+
+# Test 1: Basic single tag with two sources
+test_basic_single_tag() {
+  run_test "Basic single tag with two sources"
+
+  local output
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0" \
+    "myorg/myimage@sha256:amd64digest
+myorg/myimage@sha256:arm64digest" 2>&1)
+
+  if echo "$output" | grep -q "Creating manifest: myorg/myimage:1.0.0"; then
+    if echo "$output" | grep -q "docker buildx imagetools create -t myorg/myimage:1.0.0 myorg/myimage@sha256:amd64digest myorg/myimage@sha256:arm64digest"; then
+      pass_test "Basic single tag works"
+    else
+      fail_test "Basic single tag" "Command not formed correctly"
+    fi
+  else
+    fail_test "Basic single tag" "Manifest not created"
+  fi
+}
+
+# Test 2: Multiple tags
+test_multiple_tags() {
+  run_test "Multiple tags"
+
+  local output
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0,latest" \
+    "myorg/myimage@sha256:amd64digest
+myorg/myimage@sha256:arm64digest" 2>&1)
+
+  if echo "$output" | grep -q "Creating manifest: myorg/myimage:1.0.0"; then
+    if echo "$output" | grep -q "Creating manifest: myorg/myimage:latest"; then
+      pass_test "Multiple tags works"
+    else
+      fail_test "Multiple tags" "Second tag not created"
+    fi
+  else
+    fail_test "Multiple tags" "First tag not created"
+  fi
+}
+
+# Test 3: Whitespace handling
+test_whitespace_handling() {
+  run_test "Whitespace handling in tags and sources"
+
+  local output
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    " 1.0.0 , latest " \
+    "  myorg/myimage@sha256:amd64digest
+  myorg/myimage@sha256:arm64digest  " 2>&1)
+
+  if echo "$output" | grep -q "Creating manifest: myorg/myimage:1.0.0"; then
+    if echo "$output" | grep -q "Creating manifest: myorg/myimage:latest"; then
+      pass_test "Whitespace handling works"
+    else
+      fail_test "Whitespace handling" "Trimming failed"
+    fi
+  else
+    fail_test "Whitespace handling" "Basic parsing failed"
+  fi
+}
+
+# Test 4: Empty lines in sources
+test_empty_lines() {
+  run_test "Empty lines in sources are filtered"
+
+  local output
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0" \
+    "myorg/myimage@sha256:amd64digest
+
+myorg/myimage@sha256:arm64digest
+" 2>&1)
+
+  if echo "$output" | grep -q "Sources: myorg/myimage@sha256:amd64digest myorg/myimage@sha256:arm64digest"; then
+    pass_test "Empty lines filtered correctly"
+  else
+    fail_test "Empty lines" "Empty lines not filtered"
+  fi
+}
+
+# Test 5: Missing arguments
+test_missing_arguments() {
+  run_test "Missing arguments error handling"
+
+  local output
+  local exit_code=0
+  output=$("$SCRIPT_DIR/create-manifest.sh" 2>&1) || exit_code=$?
+
+  if [ $exit_code -ne 0 ]; then
+    if echo "$output" | grep -q "Usage:"; then
+      pass_test "Missing arguments handled correctly"
+    else
+      fail_test "Missing arguments" "No usage message shown"
+    fi
+  else
+    fail_test "Missing arguments" "Should have exited with error"
+  fi
+}
+
+# Test 6: No sources provided
+test_no_sources() {
+  run_test "No sources provided error handling"
+
+  local output
+  local exit_code=0
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0" \
+    "" 2>&1) || exit_code=$?
+
+  if [ $exit_code -ne 0 ]; then
+    if echo "$output" | grep -q "No source images provided"; then
+      pass_test "No sources error handled correctly"
+    else
+      fail_test "No sources" "Wrong error message"
+    fi
+  else
+    fail_test "No sources" "Should have exited with error"
+  fi
+}
+
+# Test 7: GITHUB_OUTPUT file
+test_github_output() {
+  run_test "GITHUB_OUTPUT file writing"
+
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  GITHUB_OUTPUT="$tmpfile" "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0,latest" \
+    "myorg/myimage@sha256:amd64digest
+myorg/myimage@sha256:arm64digest" >/dev/null 2>&1
+
+  if grep -q "manifest=myorg/myimage:1.0.0" "$tmpfile"; then
+    pass_test "GITHUB_OUTPUT written correctly"
+  else
+    fail_test "GITHUB_OUTPUT" "Output not written to file"
+  fi
+
+  rm -f "$tmpfile"
+}
+
+# Test 8: Tag-based sources (not just digests)
+test_tag_based_sources() {
+  run_test "Tag-based source references"
+
+  local output
+  output=$(GITHUB_OUTPUT=/dev/null "$SCRIPT_DIR/create-manifest.sh" \
+    "myorg/myimage" \
+    "1.0.0" \
+    "myorg/myimage:1.0.0-amd64
+myorg/myimage:1.0.0-arm64" 2>&1)
+
+  if echo "$output" | grep -q "myorg/myimage:1.0.0-amd64"; then
+    if echo "$output" | grep -q "myorg/myimage:1.0.0-arm64"; then
+      pass_test "Tag-based sources work"
+    else
+      fail_test "Tag-based sources" "Second tag not included"
+    fi
+  else
+    fail_test "Tag-based sources" "First tag not included"
+  fi
+}
+
+# Run all tests
+echo "========================================="
+echo "Running create-manifest.sh tests"
+echo "========================================="
+
+test_basic_single_tag
+test_multiple_tags
+test_whitespace_handling
+test_empty_lines
+test_missing_arguments
+test_no_sources
+test_github_output
+test_tag_based_sources
+
+# Summary
+echo ""
+echo "========================================="
+echo "Test Summary"
+echo "========================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [ $TESTS_FAILED -gt 0 ]; then
+  echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+  exit 1
+else
+  echo -e "Tests failed: $TESTS_FAILED"
+  echo ""
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Add action to combine platform-specific Docker images into a single multi-arch manifest using docker buildx imagetools.

## Changes

- **manifest/action.yaml**: Action to combine images via digests or tags
- **manifest/create-manifest.sh**: Standalone shell script for manifest creation
- **manifest/test-create-manifest.sh**: Test suite with mocked Docker (8 tests)
- **manifest/README.md**: Action documentation
- **README.md**: Multi-arch workflow guide with Mermaid diagram
- **CI**: Added shell script tests to workflow

## Test plan

- [x] Review action implementation and shell script
- [x] Verify tests pass in CI
- [x] Review documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)