### PR TITLE
feat: support metadata config in docker config file

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -25,6 +25,8 @@ Create a `.docker-config.json` file in your repository root:
 - `imageName` (required): Docker image name in format `org/name`
 - `dockerfile` (optional): Path to Dockerfile, defaults to `./Dockerfile`
 - `target` (optional): Build target stage for multi-stage builds. When specified, all image tags will automatically be suffixed with `-{target}`
+- `metadata-tags` (optional): Docker metadata-action tags input (multiline string). If specified, overrides the action input.
+- `metadata-flavor` (optional): Docker metadata-action flavor input (multiline string). If specified, overrides the action input.
 
 **Example:**
 
@@ -46,6 +48,33 @@ Create a `.docker-config.json` file in your repository root:
 ```
 
 This will build the `dev` stage and automatically tag images with the `-dev` suffix (e.g., `1.0.0-dev` instead of `1.0.0`).
+
+**Example with custom metadata:**
+
+```json
+{
+  "imageName": "turo/my-microservice",
+  "dockerfile": "./Dockerfile",
+  "metadata-tags": "type=semver,pattern={{version}}\ntype=semver,pattern={{major}}.{{minor}}",
+  "metadata-flavor": "latest=true"
+}
+```
+
+This allows you to centralize Docker metadata configuration in the config file rather than duplicating it across workflows.
+
+**Complete example with all options:**
+
+```json
+{
+  "imageName": "turo/my-microservice",
+  "dockerfile": "./Dockerfile",
+  "target": "production",
+  "metadata-tags": "type=ref,event=branch\ntype=ref,event=pr\ntype=semver,pattern={{version}}\ntype=semver,pattern={{major}}.{{minor}}\ntype=semver,pattern={{major}}",
+  "metadata-flavor": "latest=false"
+}
+```
+
+Note: When specifying multiline values in JSON, use `\n` for newlines.
 
 ## Usage
 

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -36,7 +36,7 @@ inputs:
     default: buildcache
     description: Cache tag name
   metadata-tags:
-    description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input
+    description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input. Config file value overrides this input if present.
     required: false
     default: |
       type=ref,event=branch
@@ -45,7 +45,7 @@ inputs:
       type=semver,pattern={{major}}.{{minor}}
       type=semver,pattern={{major}}
   metadata-flavor:
-    description: Docker metadata-action flavor input. See https://github.com/docker/metadata-action#flavor-input
+    description: Docker metadata-action flavor input. See https://github.com/docker/metadata-action#flavor-input. Config file value overrides this input if present.
     required: false
     default: latest=false
   build-args:
@@ -98,36 +98,29 @@ runs:
       shell: bash
       env:
         DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      run: ${{ github.action_path }}/../shared/read-docker-config.sh "$DOCKER_CONFIG_FILE"
+
+    - id: resolve-metadata
+      name: Resolve metadata inputs
+      shell: bash
+      env:
+        INPUT_METADATA_TAGS: ${{ inputs.metadata-tags }}
+        INPUT_METADATA_FLAVOR: ${{ inputs.metadata-flavor }}
+        CONFIG_METADATA_TAGS: ${{ steps.config.outputs.metadata-tags }}
+        CONFIG_METADATA_FLAVOR: ${{ steps.config.outputs.metadata-flavor }}
       run: |
-        # Validate docker config file exists
-        if [ ! -f "$DOCKER_CONFIG_FILE" ]; then
-          echo "::error::Docker config file not found: $DOCKER_CONFIG_FILE" && exit 1
-        fi
-
-        # Parse config file
-        image_name=$(jq -r .imageName "$DOCKER_CONFIG_FILE")
-        if [ -z "$image_name" ] || [ "$image_name" = "null" ]; then
-          echo "::error::imageName not found in $DOCKER_CONFIG_FILE" && exit 1
-        fi
-        echo "image-name: ${image_name}"
-        echo "image-name=${image_name}" >> $GITHUB_OUTPUT
-
-        dockerfile=$(jq -r '.dockerfile // "./Dockerfile"' "$DOCKER_CONFIG_FILE")
-        echo "Dockerfile: ${dockerfile}"
-        echo "dockerfile=${dockerfile}" >> $GITHUB_OUTPUT
-
-        target=$(jq -r '.target // ""' "$DOCKER_CONFIG_FILE")
-        echo "Target: ${target}"
-        echo "target=${target}" >> $GITHUB_OUTPUT
-
-        # Set tag suffix if target is specified
-        if [ -n "$target" ]; then
-          tag_suffix="-${target}"
+        # Use config value if present, otherwise use input
+        if [ -n "$CONFIG_METADATA_TAGS" ]; then
+          echo "metadata-tags=${CONFIG_METADATA_TAGS}" >> $GITHUB_OUTPUT
         else
-          tag_suffix=""
+          echo "metadata-tags=${INPUT_METADATA_TAGS}" >> $GITHUB_OUTPUT
         fi
-        echo "Tag suffix: ${tag_suffix}"
-        echo "tag-suffix=${tag_suffix}" >> $GITHUB_OUTPUT
+
+        if [ -n "$CONFIG_METADATA_FLAVOR" ]; then
+          echo "metadata-flavor=${CONFIG_METADATA_FLAVOR}" >> $GITHUB_OUTPUT
+        else
+          echo "metadata-flavor=${INPUT_METADATA_FLAVOR}" >> $GITHUB_OUTPUT
+        fi
 
     - name: Set up QEMU
       if: inputs.install-qemu == 'true'
@@ -151,9 +144,9 @@ runs:
       with:
         images: ${{ steps.config.outputs.image-name }}
         flavor: |
-          ${{ inputs.metadata-flavor }}
+          ${{ steps.resolve-metadata.outputs.metadata-flavor }}
           suffix=${{ steps.config.outputs.tag-suffix }}
-        tags: ${{ inputs.metadata-tags }}
+        tags: ${{ steps.resolve-metadata.outputs.metadata-tags }}
 
     - name: Build and push
       id: build

--- a/manifest/action.yaml
+++ b/manifest/action.yaml
@@ -1,9 +1,13 @@
 name: Create multi-arch Docker manifest
 description: Combine platform-specific Docker images into a single multi-arch manifest
 inputs:
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain metadata-tags and metadata-flavor.
+    default: .docker-config.json
   image-name:
-    required: true
-    description: Docker image name (e.g., org/image-name)
+    required: false
+    description: Docker image name (e.g., org/image-name). If not provided, read from config file.
   dockerhub-user:
     required: true
     description: DockerHub username
@@ -11,7 +15,7 @@ inputs:
     required: true
     description: DockerHub password
   metadata-tags:
-    description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input
+    description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input. Config file value overrides this input if present.
     required: false
     default: |
       type=ref,event=branch
@@ -20,7 +24,7 @@ inputs:
       type=semver,pattern={{major}}.{{minor}}
       type=semver,pattern={{major}}
   metadata-flavor:
-    description: Docker metadata-action flavor input. See https://github.com/docker/metadata-action#flavor-input
+    description: Docker metadata-action flavor input. See https://github.com/docker/metadata-action#flavor-input. Config file value overrides this input if present.
     required: false
     default: latest=false
   sources:
@@ -52,19 +56,62 @@ runs:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-password }}
 
+    - id: config
+      name: Read docker config
+      shell: bash
+      env:
+        DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      run: ${{ github.action_path }}/../shared/read-docker-config.sh "$DOCKER_CONFIG_FILE"
+
+    - id: resolve-image-name
+      name: Resolve image name
+      shell: bash
+      env:
+        INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+        CONFIG_IMAGE_NAME: ${{ steps.config.outputs.image-name }}
+      run: |
+        # Use input if provided, otherwise use config
+        if [ -n "$INPUT_IMAGE_NAME" ]; then
+          echo "image-name=${INPUT_IMAGE_NAME}" >> $GITHUB_OUTPUT
+        else
+          echo "image-name=${CONFIG_IMAGE_NAME}" >> $GITHUB_OUTPUT
+        fi
+
+    - id: resolve-metadata
+      name: Resolve metadata inputs
+      shell: bash
+      env:
+        INPUT_METADATA_TAGS: ${{ inputs.metadata-tags }}
+        INPUT_METADATA_FLAVOR: ${{ inputs.metadata-flavor }}
+        CONFIG_METADATA_TAGS: ${{ steps.config.outputs.metadata-tags }}
+        CONFIG_METADATA_FLAVOR: ${{ steps.config.outputs.metadata-flavor }}
+      run: |
+        # Use config value if present, otherwise use input
+        if [ -n "$CONFIG_METADATA_TAGS" ]; then
+          echo "metadata-tags=${CONFIG_METADATA_TAGS}" >> $GITHUB_OUTPUT
+        else
+          echo "metadata-tags=${INPUT_METADATA_TAGS}" >> $GITHUB_OUTPUT
+        fi
+
+        if [ -n "$CONFIG_METADATA_FLAVOR" ]; then
+          echo "metadata-flavor=${CONFIG_METADATA_FLAVOR}" >> $GITHUB_OUTPUT
+        else
+          echo "metadata-flavor=${INPUT_METADATA_FLAVOR}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Docker metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ inputs.image-name }}
-        flavor: ${{ inputs.metadata-flavor }}
-        tags: ${{ inputs.metadata-tags }}
+        images: ${{ steps.resolve-image-name.outputs.image-name }}
+        flavor: ${{ steps.resolve-metadata.outputs.metadata-flavor }}
+        tags: ${{ steps.resolve-metadata.outputs.metadata-tags }}
 
     - name: Create manifest
       id: create
       shell: bash
       env:
-        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_NAME: ${{ steps.resolve-image-name.outputs.image-name }}
         METADATA_TAGS: ${{ steps.meta.outputs.tags }}
         SOURCES: ${{ inputs.sources }}
       run: |

--- a/shared/read-docker-config.sh
+++ b/shared/read-docker-config.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Shared script to read Docker config file
+# Usage: read-docker-config.sh <config-file-path>
+#
+# Reads docker config JSON and outputs values to GITHUB_OUTPUT:
+#   - image-name: Docker image name (required)
+#   - dockerfile: Path to Dockerfile (defaults to ./Dockerfile)
+#   - target: Build target stage (optional)
+#   - tag-suffix: Tag suffix based on target (e.g., -dev)
+#   - metadata-tags: Docker metadata-action tags input (optional)
+#   - metadata-flavor: Docker metadata-action flavor input (optional)
+
+set -euo pipefail
+
+# Check for required arguments
+if [ $# -lt 1 ]; then
+  echo "::error::Usage: read-docker-config.sh <config-file-path>"
+  exit 1
+fi
+
+DOCKER_CONFIG_FILE="$1"
+
+# Validate docker config file exists
+if [ ! -f "$DOCKER_CONFIG_FILE" ]; then
+  echo "::error::Docker config file not found: $DOCKER_CONFIG_FILE" && exit 1
+fi
+
+# Parse config file
+image_name=$(jq -r .imageName "$DOCKER_CONFIG_FILE")
+if [ -z "$image_name" ] || [ "$image_name" = "null" ]; then
+  echo "::error::imageName not found in $DOCKER_CONFIG_FILE" && exit 1
+fi
+echo "image-name: ${image_name}"
+echo "image-name=${image_name}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+dockerfile=$(jq -r '.dockerfile // "./Dockerfile"' "$DOCKER_CONFIG_FILE")
+echo "Dockerfile: ${dockerfile}"
+echo "dockerfile=${dockerfile}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+target=$(jq -r '.target // ""' "$DOCKER_CONFIG_FILE")
+echo "Target: ${target}"
+echo "target=${target}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+# Set tag suffix if target is specified
+if [ -n "$target" ]; then
+  tag_suffix="-${target}"
+else
+  tag_suffix=""
+fi
+echo "Tag suffix: ${tag_suffix}"
+echo "tag-suffix=${tag_suffix}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+# Read metadata-tags from config if present
+metadata_tags=$(jq -r '.["metadata-tags"] // ""' "$DOCKER_CONFIG_FILE")
+if [ -n "$metadata_tags" ] && [ "$metadata_tags" != "null" ]; then
+  echo "Metadata tags from config: ${metadata_tags}"
+  echo "metadata-tags=${metadata_tags}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+else
+  echo "metadata-tags=" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+fi
+
+# Read metadata-flavor from config if present
+metadata_flavor=$(jq -r '.["metadata-flavor"] // ""' "$DOCKER_CONFIG_FILE")
+if [ -n "$metadata_flavor" ] && [ "$metadata_flavor" != "null" ]; then
+  echo "Metadata flavor from config: ${metadata_flavor}"
+  echo "metadata-flavor=${metadata_flavor}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+else
+  echo "metadata-flavor=" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+fi

--- a/shared/test-read-docker-config.sh
+++ b/shared/test-read-docker-config.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+# Test script for read-docker-config.sh
+# Run with: ./test-read-docker-config.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(mktemp -d)"
+EXIT_CODE=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+log_test() {
+  echo -e "${YELLOW}TEST:${NC} $1"
+}
+
+log_pass() {
+  echo -e "${GREEN}PASS:${NC} $1"
+}
+
+log_fail() {
+  echo -e "${RED}FAIL:${NC} $1"
+  EXIT_CODE=1
+}
+
+# Test 1: Valid config with all fields
+log_test "Valid config with all fields"
+cat > "$TEST_DIR/config1.json" <<EOF
+{
+  "imageName": "myorg/myimage",
+  "dockerfile": "./custom/Dockerfile",
+  "target": "production",
+  "metadata-tags": "type=semver,pattern={{version}}",
+  "metadata-flavor": "latest=true"
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output1.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config1.json" > /dev/null 2>&1; then
+  if grep -q "image-name=myorg/myimage" "$GITHUB_OUTPUT" && \
+     grep -q "dockerfile=./custom/Dockerfile" "$GITHUB_OUTPUT" && \
+     grep -q "target=production" "$GITHUB_OUTPUT" && \
+     grep -q "tag-suffix=-production" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-tags=type=semver,pattern={{version}}" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-flavor=latest=true" "$GITHUB_OUTPUT"; then
+    log_pass "All fields read correctly"
+  else
+    log_fail "Fields not read correctly"
+    cat "$GITHUB_OUTPUT"
+  fi
+else
+  log_fail "Script failed with valid config"
+fi
+
+# Test 2: Minimal config (only imageName)
+log_test "Minimal config with only imageName"
+cat > "$TEST_DIR/config2.json" <<EOF
+{
+  "imageName": "myorg/myimage"
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output2.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config2.json" > /dev/null 2>&1; then
+  if grep -q "image-name=myorg/myimage" "$GITHUB_OUTPUT" && \
+     grep -q "dockerfile=./Dockerfile" "$GITHUB_OUTPUT" && \
+     grep -q "target=$" "$GITHUB_OUTPUT" && \
+     grep -q "tag-suffix=$" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-tags=$" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-flavor=$" "$GITHUB_OUTPUT"; then
+    log_pass "Defaults applied correctly"
+  else
+    log_fail "Defaults not applied correctly"
+    cat "$GITHUB_OUTPUT"
+  fi
+else
+  log_fail "Script failed with minimal config"
+fi
+
+# Test 3: Config with target but no metadata
+log_test "Config with target but no metadata"
+cat > "$TEST_DIR/config3.json" <<EOF
+{
+  "imageName": "myorg/myimage",
+  "target": "dev"
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output3.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config3.json" > /dev/null 2>&1; then
+  if grep -q "tag-suffix=-dev" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-tags=$" "$GITHUB_OUTPUT"; then
+    log_pass "Target suffix generated, metadata empty"
+  else
+    log_fail "Target or metadata not handled correctly"
+    cat "$GITHUB_OUTPUT"
+  fi
+else
+  log_fail "Script failed with target config"
+fi
+
+# Test 4: Missing config file
+log_test "Missing config file"
+export GITHUB_OUTPUT="$TEST_DIR/output4.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/nonexistent.json" > /dev/null 2>&1; then
+  log_fail "Script should fail with missing config"
+else
+  log_pass "Script correctly fails with missing config"
+fi
+
+# Test 5: Missing imageName
+log_test "Config missing imageName"
+cat > "$TEST_DIR/config5.json" <<EOF
+{
+  "dockerfile": "./Dockerfile"
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output5.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config5.json" > /dev/null 2>&1; then
+  log_fail "Script should fail without imageName"
+else
+  log_pass "Script correctly fails without imageName"
+fi
+
+# Test 6: Metadata with multiline format (newlines as \n)
+log_test "Config with multiline metadata-tags"
+cat > "$TEST_DIR/config6.json" <<EOF
+{
+  "imageName": "myorg/myimage",
+  "metadata-tags": "type=ref,event=branch\ntype=ref,event=pr\ntype=semver,pattern={{version}}"
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output6.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config6.json" > /dev/null 2>&1; then
+  # Check if the metadata-tags contains the multiline value
+  if grep -q "metadata-tags=type=ref,event=branch" "$GITHUB_OUTPUT"; then
+    log_pass "Multiline metadata-tags handled correctly"
+  else
+    log_fail "Multiline metadata-tags not handled correctly"
+    cat "$GITHUB_OUTPUT"
+  fi
+else
+  log_fail "Script failed with multiline metadata"
+fi
+
+# Test 7: Empty metadata fields (null vs empty string)
+log_test "Config with null metadata fields"
+cat > "$TEST_DIR/config7.json" <<EOF
+{
+  "imageName": "myorg/myimage",
+  "metadata-tags": null,
+  "metadata-flavor": null
+}
+EOF
+
+export GITHUB_OUTPUT="$TEST_DIR/output7.txt"
+if "$SCRIPT_DIR/read-docker-config.sh" "$TEST_DIR/config7.json" > /dev/null 2>&1; then
+  if grep -q "metadata-tags=$" "$GITHUB_OUTPUT" && \
+     grep -q "metadata-flavor=$" "$GITHUB_OUTPUT"; then
+    log_pass "Null metadata fields handled as empty"
+  else
+    log_fail "Null metadata fields not handled correctly"
+    cat "$GITHUB_OUTPUT"
+  fi
+else
+  log_fail "Script failed with null metadata"
+fi
+
+# Summary
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+  echo -e "${GREEN}All tests passed!${NC}"
+else
+  echo -e "${RED}Some tests failed${NC}"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
Adds support for reading `metadata-tags` and `metadata-flavor` from the docker config file, with config values overriding action inputs.

## Changes
- Created shared script `shared/read-docker-config.sh` to centralize config file reading
- Updated build action to use shared script and resolve metadata from config
- Added config file support to manifest action (with same default `.docker-config.json`)
- Config values override action inputs when present
- Updated documentation with examples

## Config File Example
```json
{
  "imageName": "your-org/your-image",
  "dockerfile": "./Dockerfile",
  "target": "production",
  "metadata-tags": "type=semver,pattern={{version}}\ntype=semver,pattern={{major}}.{{minor}}",
  "metadata-flavor": "latest=false"
}
```

This allows centralizing Docker metadata configuration in the config file rather than duplicating it across workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)