### PR TITLE
Fix load-only builds not loading images into Docker daemon

### DIFF
--- a/build/action.yaml
+++ b/build/action.yaml
@@ -116,7 +116,7 @@ runs:
 
     - name: Docker metadata
       id: meta
-      if: inputs.push == 'true' && inputs.push-by-digest == 'false'
+      if: (inputs.push == 'true' || inputs.load == 'true') && inputs.push-by-digest == 'false'
       uses: docker/metadata-action@v6
       with:
         images: ${{ steps.config.outputs.image-name }}


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Fix load-only builds not loading images into Docker daemon
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
The metadata step in the build action only ran when push=true, so using load=true with push=false produced no tags. docker/build-push-action with load=true and empty tags does not actually load the image into the local Docker daemon.

This broke the documented load-only workflow (push: false, load: true) used for local testing and security scanning — the image was built in buildx but never exported to docker, making it invisible to docker images and downstream tools like wizcli.

Fix: generate metadata tags whenever the image needs to be tagged — pushing or loading. One-line condition change on the metadata step.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(build): generate metadata tags when load is true (+1/-1)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)