### PR TITLE
feat(build): support custom cache registry references

### DIFF
--- a/build/action.yaml
+++ b/build/action.yaml
@@ -122,6 +122,14 @@ runs:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-password }}
 
+    - name: Compute cache tag
+      id: cache-tag
+      shell: bash
+      env:
+        CACHE_TAG: ${{ inputs.cache-tag }}
+        IMAGE_PLATFORM: ${{ inputs.image-platform }}
+      run: echo "value=${CACHE_TAG}-${IMAGE_PLATFORM##*/}" >> $GITHUB_OUTPUT
+
     - name: Docker metadata
       id: meta
       if: (inputs.push == 'true' || inputs.load == 'true') && inputs.push-by-digest == 'false'
@@ -154,8 +162,8 @@ runs:
         # Use metadata-generated tags when pushing with tags
         tags: ${{ inputs.push-by-digest == 'false' && steps.meta.outputs.tags || '' }}
         labels: ${{ inputs.push-by-digest == 'false' && steps.meta.outputs.labels || '' }}
-        cache-from: ${{ inputs.cache-from != '' && inputs.cache-from || (inputs.cache == 'true' && format('type=registry,ref={0}:{1}', steps.config.outputs.image-name, inputs.cache-tag) || '') }}
-        cache-to: ${{ inputs.cache-to != '' && inputs.cache-to || (inputs.cache == 'true' && format('type=registry,ref={0}:{1},mode=max,compression=zstd', steps.config.outputs.image-name, inputs.cache-tag) || '') }}
+        cache-from: ${{ inputs.cache-from != '' && inputs.cache-from || (inputs.cache == 'true' && format('type=registry,ref={0}:{1}', steps.config.outputs.image-name, steps.cache-tag.outputs.value) || '') }}
+        cache-to: ${{ inputs.cache-to != '' && inputs.cache-to || (inputs.cache == 'true' && format('type=registry,ref={0}:{1},mode=max,compression=zstd', steps.config.outputs.image-name, steps.cache-tag.outputs.value) || '') }}
 
     - name: Set image reference output
       id: set-ref

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -35,6 +35,14 @@ inputs:
     required: false
     default: buildcache
     description: Cache tag name
+  cache-from:
+    required: false
+    default: ""
+    description: Custom cache-from value passed directly to docker/build-push-action. Overrides auto-generated cache-from when provided.
+  cache-to:
+    required: false
+    default: ""
+    description: Custom cache-to value passed directly to docker/build-push-action. Overrides auto-generated cache-to when provided.
   metadata-tags:
     description: Docker metadata-action tags input. See https://github.com/docker/metadata-action#tags-input
     required: false
@@ -146,8 +154,8 @@ runs:
         # Use metadata-generated tags when pushing with tags
         tags: ${{ inputs.push-by-digest == 'false' && steps.meta.outputs.tags || '' }}
         labels: ${{ inputs.push-by-digest == 'false' && steps.meta.outputs.labels || '' }}
-        cache-from: ${{ inputs.cache == 'true' && format('type=registry,ref={0}:{1}', steps.config.outputs.image-name, inputs.cache-tag) || '' }}
-        cache-to: ${{ inputs.cache == 'true' && format('type=registry,ref={0}:{1},mode=max,compression=zstd', steps.config.outputs.image-name, inputs.cache-tag) || '' }}
+        cache-from: ${{ inputs.cache-from != '' && inputs.cache-from || (inputs.cache == 'true' && format('type=registry,ref={0}:{1}', steps.config.outputs.image-name, inputs.cache-tag) || '') }}
+        cache-to: ${{ inputs.cache-to != '' && inputs.cache-to || (inputs.cache == 'true' && format('type=registry,ref={0}:{1},mode=max,compression=zstd', steps.config.outputs.image-name, inputs.cache-tag) || '') }}
 
     - name: Set image reference output
       id: set-ref


### PR DESCRIPTION
## Summary
- Add optional `cache-from` and `cache-to` inputs to the build composite action, allowing consumers to point Docker layer cache at a different registry (e.g., ECR) with custom cache refs
- When provided, these values are passed verbatim to `docker/build-push-action`; when empty (default), the existing auto-generated `type=registry` behavior is preserved
- Default cache tags are now per-architecture: the arch from `image-platform` is appended to `cache-tag` (e.g., `buildcache` → `buildcache-amd64`), eliminating the last-writer-wins race when AMD64 and ARM64 builds run in parallel

## Custom cache registry example

```yaml
- uses: open-turo/actions-docker/build@v1
  with:
    dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
    dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
    image-platform: linux/amd64
    push-by-digest: true
    cache-from: type=registry,ref=052473426605.dkr.ecr.us-east-1.amazonaws.com/dunlop-cache:amd64
    cache-to: type=registry,ref=052473426605.dkr.ecr.us-east-1.amazonaws.com/dunlop-cache:amd64,mode=max,compression=zstd
```

## Test plan
- [ ] Verify existing single-arch builds get cache tag `buildcache-amd64` (or matching arch) by default
- [ ] Verify custom `cache-from` / `cache-to` values are passed through verbatim, ignoring the default
- [ ] Verify omitting both new inputs falls back to per-arch default behavior
- [ ] Verify parallel AMD64 + ARM64 builds no longer collide on the same cache tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)